### PR TITLE
generator.py improved to accept arguments and flags using argparse

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -10,7 +10,7 @@ Official documentation site: https://www.mockaroo.com/api/docs
 parser = argparse.ArgumentParser(description='Retrieve data from Mockaroo API')
 # file is required parameter
 parser.add_argument('file',
-                    help='REQUIRED: Configuratoin file to use')
+                    help='REQUIRED: Configuration file to use')
 # key is required parameter
 parser.add_argument('-k','--key', nargs=1,
                     help='REQUIRED: Enter the API key for Mockaroo')

--- a/generator.py
+++ b/generator.py
@@ -9,6 +9,7 @@ Official documentation site: https://www.mockaroo.com/api/docs
 parser = argparse.ArgumentParser(description='Retrieve data from Mockaroo API')
 parser.add_argument('file',
                     help='Configuratoin file to use')
+# key is required parameter
 parser.add_argument('-k','--key', nargs=1,
                     help='Enter the API key for Mockaroo')
 parser.add_argument('-n', '--number', nargs=1, default=5, type=int,
@@ -18,31 +19,36 @@ parser.add_argument('-s', '--schema', nargs=1, default=['csv'],
                     help='Use one of the allowed data formats, if not spacified it will use CSV')
 args = parser.parse_args()
 
-# API URL .json at the end refers to the expected format of the output
-mockaroo_url = 'http://www.mockaroo.com/api/generate.%s' % args.schema[0]
 # API key
 mockaroo_key = args.key  # your mockaroo key
 num_rows_to_generate = args.number  # Max 1000 for the free version of the API
 
 
 def post_request():
-    # Generate the URL by appending key and count.
-    # key is required parameter
-    # if count is not given, default is one object is returned based on schema definition
-    url = mockaroo_url + '?key=' + mockaroo_key + '&count=' + str(num_rows_to_generate)
+    # Generate the URL by appending return format.
+    # API URL args.schema at the end refers to the expected format of the output
+    url = 'http://www.mockaroo.com/api/generate.%s' % args.schema[0]
 
     # schema.json refers to the schema definition of the output json to be generated
     # Refer official documentation for supported types and detailed explanation
 
     with open('schema.json', 'r') as datafile:
         fields = json.load(datafile)
-    # Make a post call to the URL
-    # Body of the post request is the schema definition of the output expected
-    response = requests.post(url=url, json=fields)
+        
+    # declare arguments required for post request to Mockaroo
+    payload = {
+            'fields':json.dumps(fields),
+            'key': args.key,
+            'count':args.number
+    }
 
-    # Write the output to a file (output.json)
+    # Make a post call to the URL
+    # Body of the post request is the schema definition of the output expected, API Key, and number of records to return
+    response = requests.post(url, params=payload)
+
+    # Write the output to a file ex. (output.json)
     with open('output.json', 'w') as outfile:
-        json.dump(response.json(), outfile)
+        outfile.write(response.text)
 
 
 if __name__ == '__main__':

--- a/generator.py
+++ b/generator.py
@@ -1,27 +1,30 @@
 import requests
 import json
 import argparse
+import sys
 
-""" This script uses Mockaroo API to generate an output json based on a schema passed to it.
+""" This script uses Mockaroo API to generate an output file based on a json schema passed to it.
 Official documentation site: https://www.mockaroo.com/api/docs
 """
 
 parser = argparse.ArgumentParser(description='Retrieve data from Mockaroo API')
+# file is required parameter
 parser.add_argument('file',
-                    help='Configuratoin file to use')
+                    help='REQUIRED: Configuratoin file to use')
 # key is required parameter
 parser.add_argument('-k','--key', nargs=1,
-                    help='Enter the API key for Mockaroo')
+                    help='REQUIRED: Enter the API key for Mockaroo')
 parser.add_argument('-n', '--number', nargs=1, default=5, type=int,
-                    help='Enter the number of records you would like returned')
+                    help='Enter the number of records you would like returned, the default is 5.')
 parser.add_argument('-s', '--schema', nargs=1, default=['csv'],
                     choices=['json','csv','txt','custom','sql','xml'],
-                    help='Use one of the allowed data formats, if not spacified it will use CSV')
+                    help='Use one of the allowed data formats, if not specified it will use CSV')
 args = parser.parse_args()
 
-# API key
-mockaroo_key = args.key  # your mockaroo key
+# convert args into easy to read variables
+mockaroo_key = args.key  # your mockaroo API key
 num_rows_to_generate = args.number  # Max 1000 for the free version of the API
+output_format = args.schema[0]
 
 
 def post_request():
@@ -32,9 +35,15 @@ def post_request():
     # schema.json refers to the schema definition of the output json to be generated
     # Refer official documentation for supported types and detailed explanation
 
-    with open(args.file, 'r') as datafile:
-        fields = json.load(datafile)
-        
+    try:
+      with open(args.file, 'r') as datafile:
+          fields = json.load(datafile)
+    except ValueError as error: #looking for errors in json loaded into script
+      print('There was an error with the JSON provided')
+      print(args.file)
+      print(error)
+      sys.exit(1)
+    
     # declare arguments required for post request to Mockaroo
     payload = {
             'fields':json.dumps(fields),
@@ -47,7 +56,7 @@ def post_request():
     response = requests.post(url, params=payload)
 
     # Write the output to a file ex. (output.json)
-    with open('output.%s' % args.schema[0], 'w') as outfile:
+    with open('output.%s' % output_format, 'w') as outfile:
         outfile.write(response.text)
 
 

--- a/generator.py
+++ b/generator.py
@@ -1,22 +1,35 @@
 import requests
 import json
+import argparse
 
 """ This script uses Mockaroo API to generate an output json based on a schema passed to it.
 Official documentation site: https://www.mockaroo.com/api/docs
 """
 
+parser = argparse.ArgumentParser(description='Retrieve data from Mockaroo API')
+parser.add_argument('file',
+                    help='Configuratoin file to use')
+parser.add_argument('-k','--key', nargs=1,
+                    help='Enter the API key for Mockaroo')
+parser.add_argument('-n', '--number', nargs=1, default=5, type=int,
+                    help='Enter the number of records you would like returned')
+parser.add_argument('-s', '--schema', nargs=1, default=['csv'],
+                    choices=['json','csv','txt','custom','sql','xml'],
+                    help='Use one of the allowed data formats, if not spacified it will use CSV')
+args = parser.parse_args()
+
 # API URL .json at the end refers to the expected format of the output
-mockaroo_url = 'http://www.mockaroo.com/api/generate.json'
+mockaroo_url = 'http://www.mockaroo.com/api/generate.%s' % args.schema[0]
 # API key
-mockaroo_key = ''  # your mockaroo key
-num_rows_to_generate = 10  # Max 1000 for the free version of the API
+mockaroo_key = args.key  # your mockaroo key
+num_rows_to_generate = args.number  # Max 1000 for the free version of the API
 
 
 def post_request():
     # Generate the URL by appending key and count.
     # key is required parameter
     # if count is not given, default is one object is returned based on schema definition
-    url = url = mockaroo_url + '?key=' + mockaroo_key + '&count=' + str(num_rows_to_generate)
+    url = mockaroo_url + '?key=' + mockaroo_key + '&count=' + str(num_rows_to_generate)
 
     # schema.json refers to the schema definition of the output json to be generated
     # Refer official documentation for supported types and detailed explanation

--- a/generator.py
+++ b/generator.py
@@ -47,7 +47,7 @@ def post_request():
     response = requests.post(url, params=payload)
 
     # Write the output to a file ex. (output.json)
-    with open('output.json', 'w') as outfile:
+    with open('output.%s' % args.schema[0], 'w') as outfile:
         outfile.write(response.text)
 
 

--- a/generator.py
+++ b/generator.py
@@ -32,7 +32,7 @@ def post_request():
     # schema.json refers to the schema definition of the output json to be generated
     # Refer official documentation for supported types and detailed explanation
 
-    with open('schema.json', 'r') as datafile:
+    with open(args.file, 'r') as datafile:
         fields = json.load(datafile)
         
     # declare arguments required for post request to Mockaroo


### PR DESCRIPTION
generator.py can now accept a users API key, as well as a given number of lines to return, default is 10.

generator will name an outfile based on the type of schema return requested. Also Argparse adds a -h output for the script.